### PR TITLE
Post OTA_STOPPED_EVENT once new image verification finished

### DIFF
--- a/main/demo_tasks/ota_over_mqtt_demo/ota_over_mqtt_demo.c
+++ b/main/demo_tasks/ota_over_mqtt_demo/ota_over_mqtt_demo.c
@@ -565,6 +565,7 @@ static void prvOtaAppCallback( OtaJobEvent_t event,
             {
                 ESP_LOGE( TAG, "Failed to set image state as accepted with error %d.", err );
             }
+
             /* Signal coreMQTT-Agent network manager that an OTA job has stopped. */
             xCoreMqttAgentManagerPost( CORE_MQTT_AGENT_OTA_STOPPED_EVENT );
             break;

--- a/main/demo_tasks/ota_over_mqtt_demo/ota_over_mqtt_demo.c
+++ b/main/demo_tasks/ota_over_mqtt_demo/ota_over_mqtt_demo.c
@@ -565,7 +565,8 @@ static void prvOtaAppCallback( OtaJobEvent_t event,
             {
                 ESP_LOGE( TAG, "Failed to set image state as accepted with error %d.", err );
             }
-
+            /* Signal coreMQTT-Agent network manager that an OTA job has stopped. */
+            xCoreMqttAgentManagerPost( CORE_MQTT_AGENT_OTA_STOPPED_EVENT );
             break;
 
         case OtaJobEventProcessed:


### PR DESCRIPTION
Post OTA_STOPPED_EVENT once new image verification finished

Description
-----------
After OTA job is finished and new firmware is verified successfully, there is no signal to `coreMQTT-Agent` network manager that an OTA job has stopped.
The signal is released only if `OtaJobEventFail`

Once case `OtaJobEventStartTest` there need to be posted: `CoreMqttAgentManagerPost(CORE_MQTT_AGENT_OTA_STOPPED_EVENT);` to recover other tasks.


Test Steps
-----------
All reproduction and test steps are described in the issue #73

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://github.com/FreeRTOS/iot-reference-esp32c3/issues/73


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
