### PR TITLE
Notify other tasks that OTA is stopped when fail to activate new image.

### DIFF
--- a/main/demo_tasks/ota_over_mqtt_demo/ota_over_mqtt_demo.c
+++ b/main/demo_tasks/ota_over_mqtt_demo/ota_over_mqtt_demo.c
@@ -535,6 +535,10 @@ static void prvOtaAppCallback( OtaJobEvent_t event,
              * performed while shutting down please set the second parameter to 0 instead of 1. */
             OTA_Shutdown( 0, 1 );
 
+            /* Notify the coreMQTT-Agent network manager that an OTA job has been terminated.
+             * Please note that due to a critical issue in the OTA PAL (Platform Abstraction Layer),
+             * the OTA service has been shut down and will not function properly after this point. */
+            xCoreMqttAgentManagerPost( CORE_MQTT_AGENT_OTA_STOPPED_EVENT );
 
             break;
 


### PR DESCRIPTION
<!--- Title -->
Notify other tasks that OTA is stopped when fail to activate new image.

Description
-----------
<!--- Describe your changes in detail -->
As #73 discussed (in additional question), when OTA fail to activate new image, we should notify other tasks to continue.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
1. Run OTA test with hacking that OTA pal fail to activate the image like below.
```
OtaErr_t OTA_ActivateNewImage( void )
{
    // skip for simplify

    if( ( otaAgent.pOtaInterface != NULL ) && ( otaAgent.pOtaInterface->pal.activate != NULL ) )
    {
        // comment out below line to make activation fail to test this scenario.
        // palStatus = otaAgent.pOtaInterface->pal.activate( &( otaAgent.fileContext ) );
    }

    // skip for simplify

    return ( ( palStatus >> OTA_PAL_SUB_BITS ) == ( uint32_t ) OtaPalSuccess ) ? OtaErrNone : OtaErrActivateFailed;
}
```
2. Check if publish demo is running normally.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
