### PR TITLE
Fix CI build tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,4 +56,4 @@ jobs:
           esp_idf_version: ${{ matrix.esp_idf_version }}
           target: ${{ matrix.esp_target }}
           path: './'
-          command: python -m pip install --upgrade idf-component-manager || idf.py build
+          command: python -m pip install --upgrade idf-component-manager && idf.py build


### PR DESCRIPTION
<!--- Title -->
Fix CI build tests

Description
-----------
<!--- Describe your changes in detail -->
The CI build actions don't execute correctly because of `||` operation. Fix it by replacing it with `&&`.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Check [actions](https://github.com/ActoryOu/iot-reference-esp32c3/actions/runs/10130295585/job/28011427008) result. Note that without #99 fix, the build results are all failing.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [NA] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
