### PR TITLE
Use static buffer for OTA decoded buffer

### DIFF
--- a/main/demo_tasks/ota_over_mqtt_demo/ota_over_mqtt_demo.c
+++ b/main/demo_tasks/ota_over_mqtt_demo/ota_over_mqtt_demo.c
@@ -1186,7 +1186,7 @@ static void processOTAEvents( void )
             }
             else
             {
-                uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
+                static uint8_t decodedData[ mqttFileDownloader_CONFIG_BLOCK_SIZE ];
                 size_t decodedDataLength = 0;
                 MQTTFileDownloaderStatus_t xReturnStatus;
                 int16_t result = -1;


### PR DESCRIPTION

<!--- Title -->

Description
-----------
Default block size is 4096 and allocated on stack, which cause the stack overflow. Using static memory for this buffer to prevent altering the stack size in the future.

Test Steps
-----------
After this PR, the demo should able to run without crash.

```
I (801) main: Application version number: 0.0.0
I (811) temp_sub_pub_and_led_control_demo: Sending subscribe request to agent for topic filter: /filter/TempSubPubLED with id 1
I (821) ota_over_mqtt_demo: OTA over MQTT demo, Application version 0.0.0
I (831) pp: pp rom version: 9387209
I (831) net80211: net80211 rom version: 9387209
I (841) wifi:wifi driver task: 3fcb5fd8, prio:23, stack:6656, core=0
I (851) wifi:wifi firmware version: 3e0076f
I (851) wifi:wifi certification version: v7.0
I (851) wifi:config NVS flash: enabled
I (851) wifi:config nano formating: disabled
I (861) wifi:Init data frame dynamic rx buffer num: 32
I (861) wifi:Init static rx mgmt buffer num: 5
I (871) wifi:Init management short buffer num: 32
I (871) wifi:Init dynamic tx buffer num: 32
I (871) wifi:Init static tx FG buffer num: 2
I (881) wifi:Init static rx buffer size: 1600
I (881) wifi:Init static rx buffer num: 10
I (891) wifi:Init dynamic rx buffer num: 32
I (891) wifi_init: rx ba win: 6
I (891) wifi_init: tcpip mbox: 32
I (901) wifi_init: udp mbox: 6
I (901) wifi_init: tcp mbox: 6
I (901) wifi_init: tcp tx win: 5760
I (911) wifi_init: tcp rx win: 5760
I (911) wifi_init: tcp mss: 1440
I (921) wifi_init: WiFi IRAM OP enabled
I (921) wifi_init: WiFi RX IRAM OP enabled
I (931) wifi_prov_scheme_ble: BT memory released
I (931) app_wifi: Already provisioned, starting Wi-Fi STA
I (941) wifi_prov_scheme_ble: BTDM memory released
I (941) phy_init: phy_version 1170,f4aea9b,Apr 30 2024,10:49:24
I (991) wifi:mode : sta (60:55:f9:c9:2f:68)
I (991) wifi:enable tsf
I (3401) wifi:new:<11,0>, old:<1,0>, ap:<255,255>, sta:<11,0>, prof:1
I (3401) wifi:state: init -> auth (b0)
I (3401) wifi:state: auth -> assoc (0)
I (3401) wifi:state: assoc -> run (10)
I (3421) wifi:connected with Guest, aid = 1, channel 11, BW20, bssid = 1c:28:af:17:c3:c1
I (3421) wifi:security: WPA2-PSK, phy: bgn, rssi: -55
I (3431) wifi:pm start, type: 1

I (3431) wifi:dp: 1, bi: 102400, li: 3, scale listen interval from 307200 us to 307200 us
I (3431) wifi:set rx beacon pti, rx_bcn_pti: 14, bcn_timeout: 25000, mt_pti: 14, mt_time: 10000
I (3451) wifi:AP's beacon interval = 102400 us, DTIM period = 1
I (3481) wifi:<ba-add>idx:0 (ifx:0, 1c:28:af:17:c3:c1), tid:0, ssn:2, winSize:64
I (4441) core_mqtt_agent_manager: WiFi connected.
I (4441) app_wifi: Connected with IP Address:172.24.0.97
I (4441) esp_netif_handlers: sta ip: 172.24.0.97, mask: 255.255.128.0, gw: 172.24.0.1
I (4451) main_task: Returned from app_main()
I (4471) wifi:<ba-add>idx:1 (ifx:0, 1c:28:af:17:c3:c1), tid:4, ssn:0, winSize:64
I (6331) core_mqtt_agent_manager: TLS connection established.
I (6831) coreMQTT: MQTT connection established with the broker.
I (6831) core_mqtt_agent_manager: Session present: 0

I (6831) sub_pub_unsub_demo: coreMQTT-Agent connected.
I (6841) temp_sub_pub_and_led_control_demo: coreMQTT-Agent connected.
I (6841) ota_over_mqtt_demo: coreMQTT-Agent connected. Resuming OTA agent.
I (6851) core_mqtt_agent_manager: coreMQTT-Agent connected.
I (6871) sub_pub_unsub_demo: Task "SubPub0" sending subscribe request to coreMQTT-Agent for topic filter: /filter/SubPub0 with id 1
I (6871) ota_over_mqtt_demo: Request Job Document event Received

I (7561) temp_sub_pub_and_led_control_demo: Received subscribe ack for topic /filter/TempSubPubLED containing ID 1
I (7561) temp_sub_pub_and_led_control_demo: Sending publish request to agent with message "{"temperatureSensor":{ "taskName": "TempSubPubLED", "temperatureValue": 0.000000, "iteration": 0}}" on topic "/filter/TempSubPubLED"
I (7581) temp_sub_pub_and_led_control_demo: Task TempSubPubLED waiting for publish 0 to complete.
I (10011) sub_pub_unsub_demo: Subscribe 1 for topic filter /filter/SubPub0 succeeded for task "SubPub0".
I (10011) sub_pub_unsub_demo: Task "SubPub0" sending publish request to coreMQTT-Agent with message "SubPub0" on topic "/filter/SubPub0" with ID 2.
I (10031) sub_pub_unsub_demo: Task "SubPub0" waiting for publish 2 to complete.
I (12021) ota_over_mqtt_demo: Sent PUBLISH packet to broker $aws/things/st_discovery/jobs/start-next to broker.


I (12471) coreMQTT: De-serialized incoming PUBLISH packet: DeserializerResult=MQTTSuccess.
I (12471) coreMQTT: State record updated. New state=MQTTPublishDone.
I (12481) ota_over_mqtt_demo: Received Job Document event Received

I (12481) ota_over_mqtt_demo: This is not an OTA job
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] ~~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~~

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
