### PR TITLE
UseSecurityFeatures.md: Use cust_flash_tlv format

### DIFF
--- a/UseSecurityFeatures.md
+++ b/UseSecurityFeatures.md
@@ -55,7 +55,7 @@ running this command, an eFuse block in the ESP32-C3 will be burnt with a
     this value will be `RSA 2048`
 
 ```sh
-python managed_components/espressif__esp_secure_cert_mgr/tools/configure_esp_secure_cert.py -p PORT --configure_ds --keep_ds_data_on_host --ca-cert CA_CERT_FILEPATH --device-cert DEVICE_CERT_FILEPATH --private-key PRIVATE_KEY_FILEPATH --target_chip CHIP_TYPE --secure_cert_type cust_flash --priv_key_algo PRIVATE_KEY_ALGORITHM
+python managed_components/espressif__esp_secure_cert_mgr/tools/configure_esp_secure_cert.py -p PORT --configure_ds --keep_ds_data_on_host --ca-cert CA_CERT_FILEPATH --device-cert DEVICE_CERT_FILEPATH --private-key PRIVATE_KEY_FILEPATH --target_chip CHIP_TYPE --secure_cert_type cust_flash_tlv --priv_key_algo PRIVATE_KEY_ALGORITHM
 ```
 - Type in **BURN** when prompted to.
 


### PR DESCRIPTION
<!--- Title -->
Update `UseSecurityFeature.md` file to use correct flash_format for generating esp_secure_cert partition

Description
-----------
        The cust_flash format has been deprecated by the http://github.com/espressif/esp_secure_cert_mgr component.
        Updating the document to use cust_flash_tlv format for storing the PKI data instead of cust_flash.

Test Steps
-----------
Currently if the user follows the steps given to use cust_flash format then they observe a failure with the default configurations for esp_secure_cert_mgr component.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [] I have modified and/or added unit-tests to cover the code changes in this Pull Request. (No unit-test required)

Related Issue
-----------
https://github.com/espressif/esp-idf/issues/14300

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

