### PR TITLE
Update GettingStartedGuide.md with a minor fix to the step that build and flash the demo project

### DIFF
--- a/GettingStartedGuide.md
+++ b/GettingStartedGuide.md
@@ -180,7 +180,7 @@ The directly supported chips are the ones listed in
   when using an unsupported ESP chip.
 
 ```sh
-idf.py -p PORT flash monitor;
+idf.py -p PORT flash monitor
 ```
 
 Replace **PORT** with the serial port to which the ESP32-C3 is connected.


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR updates GettingStartedGuide.md with a minor fix to the steps that build and flash the demo project. The semi-colon at the end of the command causes failure when executed on Windows 10 CMD:

```
Hash of data verified. 
Compressed 8192 bytes to 31... 
Writing at 0x00019000... (100 %) 
Wrote 8192 bytes (31 compressed) at 0x00019000 in 0.1 seconds (effective 522.2 kbit/s)... 
Hash of data verified. 

Leaving... 
Hard resetting via RTS pin... 
Executing action: monitor; 
ninja: error: unknown target 'monitor;', did you mean 'monitor'? 
command "monitor;" is not known to idf.py and is not a Ninja target 
```

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Run the command

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- ~[ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.~

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
